### PR TITLE
fix: should not fail when pass config via cli

### DIFF
--- a/requester/fixtures/diff.yml
+++ b/requester/fixtures/diff.yml
@@ -16,6 +16,8 @@ rust:
       - date
       - via
       - x-amz-cf-id
+      - report-to
+      - reporting-endpoints
 todo:
   request1:
     url: https://jsonplaceholder.typicode.com/todos/1

--- a/xdiff/src/main.rs
+++ b/xdiff/src/main.rs
@@ -99,7 +99,10 @@ async fn parse(output: &mut Vec<String>) -> Result<()> {
 }
 
 async fn run(output: &mut Vec<String>, args: RunArgs) -> Result<()> {
-    let config_file = args.config.unwrap_or(get_default_config("xdiff.yml")?);
+    let config_file = match args.config {
+        Some(path) => path,
+        None => get_default_config("xdiff.yml")?
+    };
     let diff_config = DiffConfig::try_load(&config_file).await?;
 
     let mut config = diff_config.get(&args.profile)?.clone();


### PR DESCRIPTION
fix #1 
Should not error when config is specified via command line arguments but with no default configs created yet.
Also update the example `diff.yml` to make test pass