### PR TITLE
feat: fix `--config` path resolution and add JSONPath filtering support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "alloc-no-stdlib"
 version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -174,6 +183,15 @@ name = "bitflags"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
+
+[[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
 
 [[package]]
 name = "brotli"
@@ -333,12 +351,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+dependencies = [
+ "generic-array",
+ "typenum",
 ]
 
 [[package]]
@@ -397,6 +434,16 @@ dependencies = [
  "tempfile",
  "thiserror 1.0.69",
  "zeroize",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
 ]
 
 [[package]]
@@ -500,6 +547,16 @@ dependencies = [
  "futures-task",
  "pin-project-lite",
  "pin-utils",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
 ]
 
 [[package]]
@@ -878,6 +935,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonpath-rust"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d057f8fd19e20c3f14d3663983397155739b6bc1148dc5cd4c4a1a5b3130eb0"
+dependencies = [
+ "pest",
+ "pest_derive",
+ "regex",
+ "serde_json",
+ "thiserror 2.0.12",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1037,6 +1107,50 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
+name = "pest"
+version = "2.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1db05f56d34358a8b1066f67cbb203ee3e7ed2ba674a6263a1d5ec6db2204323"
+dependencies = [
+ "memchr",
+ "thiserror 2.0.12",
+ "ucd-trie",
+]
+
+[[package]]
+name = "pest_derive"
+version = "2.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb056d9e8ea77922845ec74a1c4e8fb17e7c218cc4fc11a15c5d25e189aa40bc"
+dependencies = [
+ "pest",
+ "pest_generator",
+]
+
+[[package]]
+name = "pest_generator"
+version = "2.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87e404e638f781eb3202dc82db6760c8ae8a1eeef7fb3fa8264b2ef280504966"
+dependencies = [
+ "pest",
+ "pest_meta",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "pest_meta"
+version = "2.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edd1101f170f5903fde0914f899bb503d9ff5271d7ba76bbb70bea63690cc0d5"
+dependencies = [
+ "pest",
+ "sha2",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1113,7 +1227,7 @@ dependencies = [
  "rustc-hash",
  "rustls",
  "socket2",
- "thiserror 2.0.7",
+ "thiserror 2.0.12",
  "tokio",
  "tracing",
 ]
@@ -1132,7 +1246,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror 2.0.7",
+ "thiserror 2.0.12",
  "tinyvec",
  "tracing",
  "web-time",
@@ -1198,6 +1312,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b6dfecf2c74bce2466cabf93f6664d6998a69eb21e39f4207930065b27b771f"
 dependencies = [
  "bitflags 2.6.0",
+]
+
+[[package]]
+name = "regex"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -1453,6 +1590,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "shell-words"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1608,11 +1756,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.7"
+version = "2.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93605438cbd668185516ab499d589afb7ee1859ea3d5fc8f6b0755e1c7443767"
+checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
 dependencies = [
- "thiserror-impl 2.0.7",
+ "thiserror-impl 2.0.12",
 ]
 
 [[package]]
@@ -1628,9 +1776,9 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.7"
+version = "2.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1d8749b4531af2117677a5fcd12b1348a3fe2b81e36e61ffeac5c4aa3273e36"
+checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1777,6 +1925,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "typenum"
+version = "1.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
+
+[[package]]
+name = "ucd-trie"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1829,6 +1989,12 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "walkdir"
@@ -2231,6 +2397,7 @@ dependencies = [
  "console",
  "http",
  "http-serde",
+ "jsonpath-rust",
  "reqwest",
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2349,7 +2349,7 @@ checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
 
 [[package]]
 name = "xdiff"
-version = "0.4.4"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "atty",
@@ -2364,7 +2364,7 @@ dependencies = [
 
 [[package]]
 name = "xreq"
-version = "0.4.4"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "atty",
@@ -2391,7 +2391,7 @@ dependencies = [
 
 [[package]]
 name = "xreq-lib"
-version = "0.4.2"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "console",

--- a/README.md
+++ b/README.md
@@ -33,6 +33,44 @@ rust:
       - x-amz-cf-id
 ```
 
+### JSON Path Support
+
+xdiff supports JSONPath expressions to compare specific parts of JSON responses instead of the entire response. This is useful when you only want to compare specific fields or arrays within large JSON structures.
+
+You can specify a JSON path in two ways:
+
+#### 1. Via Command Line Parameter
+
+```bash
+xdiff run -p todo -c requester/fixtures/diff.yml --jsonpath "$.user.profile.email"
+```
+
+#### 2. Via Configuration File
+
+```yaml
+---
+api_comparison:
+  request1:
+    url: https://api.example.com/users/1
+  request2:
+    url: https://api.example.com/users/2
+  response:
+    skip_headers:
+      - date
+      - etag
+    jsonpath: "$.user.profile.email"
+```
+
+#### JSON Path Examples
+
+Here are some common JSON path expressions you can use:
+
+- `$.title` - Extract the title field from the root
+- `$.containers[*].slug` - Extract slug fields from all items in the containers array
+- `$.users[0].name` - Extract the name of the first user
+- `$.data[?(@.active == true)]` - Extract all items where active is true
+- `$..email` - Extract all email fields recursively
+
 You could put the configuration in `~/.config/xdiff.yml`, or `/etc/xdiff.yml`, or `~/xdiff.yml`. The xdiff CLI will look for configuration from these paths.
 
 ### How to use xdiff?
@@ -68,6 +106,7 @@ OPTIONS:
     -e <EXTRA_PARAMS>          Extra parameters to pass to the API
     -h, --help                 Print help information
     -p, --profile <PROFILE>    API profile to use
+        --jsonpath <JSONPATH>  JSON path to extract specific values from response (e.g., $.containers[*].slug)
 ```
 
 An example:
@@ -79,6 +118,21 @@ xdiff run -p todo -c requester/fixtures/diff.yml -e a=1 -e b=2
 This will use the todo profile in the diff.yml defined in `requester/fixtures`, and add extra params for query string with a=1, b=2. Output look like this:
 
 ![screenshot](docs/images/screenshot1.png)
+
+#### JSON Path Usage Examples
+
+Compare only specific fields:
+
+```bash
+# Compare only the title field from JSON responses
+xdiff run -p api_profile -c config.yml --jsonpath "$.title"
+
+# Compare user names from an array
+xdiff run -p users_profile -c config.yml --jsonpath "$.users[*].name"
+
+# Compare nested object fields
+xdiff run -p profile -c config.yml --jsonpath "$.data.user.profile.email"
+```
 
 If you find writing the config file tedious, you can use the `xdiff parse` subcommand to parse a URL and print the generated config.
 

--- a/cli-utils/Cargo.toml
+++ b/cli-utils/Cargo.toml
@@ -19,4 +19,4 @@ anyhow = "1.0.94"
 atty = "0.2.14"
 syntect = "5.2.0"
 
-xreq-lib = { version = "0.4.0", path = "../requester" }
+xreq-lib = { version = "0.5.0", path = "../requester" }

--- a/requester/Cargo.toml
+++ b/requester/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xreq-lib"
-version = "0.4.2"
+version = "0.5.0"
 edition = "2021"
 license = "MIT"
 documentation = "https://docs.rs/xreq-lib"

--- a/requester/Cargo.toml
+++ b/requester/Cargo.toml
@@ -18,6 +18,7 @@ anyhow = "1.0.94"
 console = "0.15.8"
 http = "1"
 http-serde = "2"
+jsonpath-rust = "1.0.3"
 reqwest = { version = "0.12", features = [
   "rustls-tls",
   "gzip",

--- a/requester/fixtures/diff.yml
+++ b/requester/fixtures/diff.yml
@@ -28,3 +28,13 @@ todo:
   response:
     skip_headers:
       - report-to
+
+jsonpath_test:
+  request1:
+    url: https://jsonplaceholder.typicode.com/todos/1
+  request2:
+    url: https://jsonplaceholder.typicode.com/todos/2
+  response:
+    skip_headers:
+      - report-to
+    jsonpath: "$.title"

--- a/requester/src/diff.rs
+++ b/requester/src/diff.rs
@@ -42,7 +42,7 @@ pub enum DiffResult {
 
 impl ResponseContext {
     pub fn new(skip_headers: Vec<String>) -> Self {
-        Self { 
+        Self {
             skip_headers,
             jsonpath: None,
         }
@@ -166,7 +166,7 @@ impl DiffContext {
                 // No JSON path specified, use the full JSON
                 json
             };
-            
+
             body = serde_json::to_string_pretty(&processed_json)?;
         }
 
@@ -178,11 +178,12 @@ impl DiffContext {
     /// Extract values from JSON using the specified JSON path
     fn extract_jsonpath_values(&self, json: &Value, jsonpath_str: &str) -> Result<Value> {
         use jsonpath_rust::JsonPath;
-        
+
         // Apply the JSON path to extract values
-        let extracted = json.query(jsonpath_str)
+        let extracted = json
+            .query(jsonpath_str)
             .map_err(|e| anyhow::anyhow!("Invalid JSON path '{}': {}", jsonpath_str, e))?;
-        
+
         // Convert the extracted slice to a JSON array
         // If only one value is found, return it directly; otherwise return an array
         match extracted.len() {
@@ -271,7 +272,9 @@ mod tests {
             "completed": false
         });
 
-        let result = diff_context.extract_jsonpath_values(&json, "$.title").unwrap();
+        let result = diff_context
+            .extract_jsonpath_values(&json, "$.title")
+            .unwrap();
         assert_eq!(result, json!("Test Title"));
     }
 
@@ -294,7 +297,10 @@ mod tests {
                 body: None,
                 user_agent: None,
             },
-            response: ResponseContext::with_jsonpath(vec![], Some("$.containers[*].slug".to_string())),
+            response: ResponseContext::with_jsonpath(
+                vec![],
+                Some("$.containers[*].slug".to_string()),
+            ),
         };
 
         let json = json!({
@@ -304,7 +310,9 @@ mod tests {
             ]
         });
 
-        let result = diff_context.extract_jsonpath_values(&json, "$.containers[*].slug").unwrap();
+        let result = diff_context
+            .extract_jsonpath_values(&json, "$.containers[*].slug")
+            .unwrap();
         assert_eq!(result, json!(["container-1", "container-2"]));
     }
 
@@ -335,7 +343,9 @@ mod tests {
             "id": 1
         });
 
-        let result = diff_context.extract_jsonpath_values(&json, "$.nonexistent").unwrap();
+        let result = diff_context
+            .extract_jsonpath_values(&json, "$.nonexistent")
+            .unwrap();
         assert_eq!(result, Value::Null);
     }
 
@@ -367,7 +377,10 @@ mod tests {
 
         let result = diff_context.extract_jsonpath_values(&json, "invalid_path");
         assert!(result.is_err());
-        assert!(result.unwrap_err().to_string().contains("Invalid JSON path"));
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("Invalid JSON path"));
     }
 
     #[test]
@@ -393,7 +406,7 @@ mod tests {
     async fn test_jsonpath_test_profile() {
         let config = DiffConfig::try_load("fixtures/diff.yml").await.unwrap();
         let context = config.get("jsonpath_test").unwrap();
-        
+
         // Verify that the jsonpath is correctly loaded from the config
         assert_eq!(context.response.jsonpath, Some("$.title".to_string()));
     }

--- a/requester/src/diff.rs
+++ b/requester/src/diff.rs
@@ -30,6 +30,8 @@ fn is_default_response(r: &ResponseContext) -> bool {
 pub struct ResponseContext {
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub skip_headers: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub jsonpath: Option<String>,
 }
 
 #[derive(Debug, PartialEq, Eq)]
@@ -40,7 +42,18 @@ pub enum DiffResult {
 
 impl ResponseContext {
     pub fn new(skip_headers: Vec<String>) -> Self {
-        Self { skip_headers }
+        Self { 
+            skip_headers,
+            jsonpath: None,
+        }
+    }
+
+    /// Create ResponseContext with JSON path filter
+    pub fn with_jsonpath(skip_headers: Vec<String>, jsonpath: Option<String>) -> Self {
+        Self {
+            skip_headers,
+            jsonpath,
+        }
     }
 }
 
@@ -144,13 +157,39 @@ impl DiffContext {
 
         let mut body = res.text().await?;
 
+        // Process JSON body with optional JSON path extraction
         if let Ok(json) = serde_json::from_str::<Value>(&body) {
-            body = serde_json::to_string_pretty(&json)?;
+            let processed_json = if let Some(ref jsonpath_str) = self.response.jsonpath {
+                // Apply JSON path extraction
+                self.extract_jsonpath_values(&json, jsonpath_str)?
+            } else {
+                // No JSON path specified, use the full JSON
+                json
+            };
+            
+            body = serde_json::to_string_pretty(&processed_json)?;
         }
 
         writeln!(&mut buf, "{}", body).unwrap();
 
         Ok(String::from_utf8(buf)?)
+    }
+
+    /// Extract values from JSON using the specified JSON path
+    fn extract_jsonpath_values(&self, json: &Value, jsonpath_str: &str) -> Result<Value> {
+        use jsonpath_rust::JsonPath;
+        
+        // Apply the JSON path to extract values
+        let extracted = json.query(jsonpath_str)
+            .map_err(|e| anyhow::anyhow!("Invalid JSON path '{}': {}", jsonpath_str, e))?;
+        
+        // Convert the extracted slice to a JSON array
+        // If only one value is found, return it directly; otherwise return an array
+        match extracted.len() {
+            0 => Ok(Value::Null),
+            1 => Ok(extracted[0].clone()),
+            _ => Ok(Value::Array(extracted.into_iter().cloned().collect())),
+        }
     }
 }
 
@@ -195,11 +234,167 @@ fn build_diff(headers: String, old: String, new: String) -> Result<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serde_json::json;
 
     #[tokio::test]
     async fn diff_request_should_work() {
         let config = DiffConfig::try_load("fixtures/diff.yml").await.unwrap();
         let result = config.diff("rust").await.unwrap();
         assert_eq!(result, DiffResult::Equal);
+    }
+
+    #[test]
+    fn test_extract_jsonpath_values_simple_field() {
+        let diff_context = DiffContext {
+            request1: RequestContext {
+                method: http::Method::GET,
+                url: "http://example.com".parse().unwrap(),
+                params: json!({}),
+                headers: http::HeaderMap::new(),
+                body: None,
+                user_agent: None,
+            },
+            request2: RequestContext {
+                method: http::Method::GET,
+                url: "http://example.com".parse().unwrap(),
+                params: json!({}),
+                headers: http::HeaderMap::new(),
+                body: None,
+                user_agent: None,
+            },
+            response: ResponseContext::with_jsonpath(vec![], Some("$.title".to_string())),
+        };
+
+        let json = json!({
+            "title": "Test Title",
+            "id": 1,
+            "completed": false
+        });
+
+        let result = diff_context.extract_jsonpath_values(&json, "$.title").unwrap();
+        assert_eq!(result, json!("Test Title"));
+    }
+
+    #[test]
+    fn test_extract_jsonpath_values_array_field() {
+        let diff_context = DiffContext {
+            request1: RequestContext {
+                method: http::Method::GET,
+                url: "http://example.com".parse().unwrap(),
+                params: json!({}),
+                headers: http::HeaderMap::new(),
+                body: None,
+                user_agent: None,
+            },
+            request2: RequestContext {
+                method: http::Method::GET,
+                url: "http://example.com".parse().unwrap(),
+                params: json!({}),
+                headers: http::HeaderMap::new(),
+                body: None,
+                user_agent: None,
+            },
+            response: ResponseContext::with_jsonpath(vec![], Some("$.containers[*].slug".to_string())),
+        };
+
+        let json = json!({
+            "containers": [
+                {"slug": "container-1", "id": 1},
+                {"slug": "container-2", "id": 2}
+            ]
+        });
+
+        let result = diff_context.extract_jsonpath_values(&json, "$.containers[*].slug").unwrap();
+        assert_eq!(result, json!(["container-1", "container-2"]));
+    }
+
+    #[test]
+    fn test_extract_jsonpath_values_not_found() {
+        let diff_context = DiffContext {
+            request1: RequestContext {
+                method: http::Method::GET,
+                url: "http://example.com".parse().unwrap(),
+                params: json!({}),
+                headers: http::HeaderMap::new(),
+                body: None,
+                user_agent: None,
+            },
+            request2: RequestContext {
+                method: http::Method::GET,
+                url: "http://example.com".parse().unwrap(),
+                params: json!({}),
+                headers: http::HeaderMap::new(),
+                body: None,
+                user_agent: None,
+            },
+            response: ResponseContext::with_jsonpath(vec![], Some("$.nonexistent".to_string())),
+        };
+
+        let json = json!({
+            "title": "Test Title",
+            "id": 1
+        });
+
+        let result = diff_context.extract_jsonpath_values(&json, "$.nonexistent").unwrap();
+        assert_eq!(result, Value::Null);
+    }
+
+    #[test]
+    fn test_extract_jsonpath_values_invalid_path() {
+        let diff_context = DiffContext {
+            request1: RequestContext {
+                method: http::Method::GET,
+                url: "http://example.com".parse().unwrap(),
+                params: json!({}),
+                headers: http::HeaderMap::new(),
+                body: None,
+                user_agent: None,
+            },
+            request2: RequestContext {
+                method: http::Method::GET,
+                url: "http://example.com".parse().unwrap(),
+                params: json!({}),
+                headers: http::HeaderMap::new(),
+                body: None,
+                user_agent: None,
+            },
+            response: ResponseContext::with_jsonpath(vec![], Some("invalid_path".to_string())),
+        };
+
+        let json = json!({
+            "title": "Test Title"
+        });
+
+        let result = diff_context.extract_jsonpath_values(&json, "invalid_path");
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("Invalid JSON path"));
+    }
+
+    #[test]
+    fn test_response_context_with_jsonpath() {
+        let response_ctx = ResponseContext::with_jsonpath(
+            vec!["header1".to_string(), "header2".to_string()],
+            Some("$.data[*].name".to_string()),
+        );
+
+        assert_eq!(response_ctx.skip_headers, vec!["header1", "header2"]);
+        assert_eq!(response_ctx.jsonpath, Some("$.data[*].name".to_string()));
+    }
+
+    #[test]
+    fn test_response_context_new_default() {
+        let response_ctx = ResponseContext::new(vec!["header1".to_string()]);
+
+        assert_eq!(response_ctx.skip_headers, vec!["header1"]);
+        assert_eq!(response_ctx.jsonpath, None);
+    }
+
+    #[tokio::test]
+    async fn test_jsonpath_test_profile() {
+        let config = DiffConfig::try_load("fixtures/diff.yml").await.unwrap();
+        let context = config.get("jsonpath_test").unwrap();
+        
+        // Verify that the jsonpath is correctly loaded from the config
+        assert_eq!(context.response.jsonpath, Some("$.title".to_string()));
     }
 }

--- a/xdiff/Cargo.toml
+++ b/xdiff/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xdiff"
-version = "0.4.4"
+version = "0.5.0"
 edition = "2021"
 license = "MIT"
 documentation = "https://docs.rs/xdiff"
@@ -23,4 +23,4 @@ serde_json = "1.0.133"
 serde_yaml = "0.9.34"
 
 xreq-cli-utils = { version = "0.3.2", path = "../cli-utils" }
-xreq-lib = { version = "0.4.2", path = "../requester" }
+xreq-lib = { version = "0.5.0", path = "../requester" }

--- a/xdiff/src/main.rs
+++ b/xdiff/src/main.rs
@@ -34,6 +34,10 @@ struct RunArgs {
     /// Path to the config file.
     #[clap(short, long, value_parser = get_config_file)]
     config: Option<PathBuf>,
+
+    /// JSON path to extract specific values from response (e.g., $.containers[*].slug).
+    #[clap(long, value_parser)]
+    jsonpath: Option<String>,
 }
 
 #[tokio::main]
@@ -99,13 +103,21 @@ async fn parse(output: &mut Vec<String>) -> Result<()> {
 }
 
 async fn run(output: &mut Vec<String>, args: RunArgs) -> Result<()> {
-    let config_file = args.config.unwrap_or(get_default_config("xdiff.yml")?);
+    let config_file = match args.config {
+        Some(path) => path,
+        None => get_default_config("xdiff.yml")?,
+    };
     let diff_config = DiffConfig::try_load(&config_file).await?;
 
     let mut config = diff_config.get(&args.profile)?.clone();
 
     config.request1.update(&args.extra_params)?;
     config.request2.update(&args.extra_params)?;
+
+    // Apply JSON path if provided
+    if let Some(ref jsonpath) = args.jsonpath {
+        config.response.jsonpath = Some(jsonpath.clone());
+    }
 
     let result = config.diff().await?;
 

--- a/xreq/Cargo.toml
+++ b/xreq/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xreq"
-version = "0.4.4"
+version = "0.5.0"
 edition = "2021"
 license = "MIT"
 documentation = "https://docs.rs/xreq"
@@ -25,4 +25,4 @@ serde_yaml = "0.9.34"
 tokio = { version = "1.42.0", features = ["full"] }
 
 xreq-cli-utils = { version = "0.3.2", path = "../cli-utils" }
-xreq-lib = { version = "0.4.2", path = "../requester" }
+xreq-lib = { version = "0.5.0", path = "../requester" }


### PR DESCRIPTION
## Summary

This PR fixes a config path issue and adds JSONPath filtering.

## Problems Solved

I encountered two problems while using xdiff:

1. **Custom config paths didn't work**: The `--config` parameter wasn't resolving paths correctly
2. **Large JSON responses were overwhelming**: I needed a way to compare only specific fields instead of entire JSON objects

## Changes

### Config Path Fix
- Fixed `--config` parameter to properly resolve custom configuration file paths

### JSONPath Filtering Support  
- Added `--jsonpath` CLI parameter to extract specific JSON fields before comparison
- Added `jsonpath` support in YAML config files
- Supports expressions like `$.title`, `$.containers[*].slug`, `$.users[?(@.active == true)]`

## Usage

**Command line:**
```bash
xdiff run -p profile -c config.yml --jsonpath "$.user.hobbies[*].name"
```

**Config file:**
```yaml
response:
  skip_headers: [date, etag]
  jsonpath: "$.user.hobbies[*].name"
```
